### PR TITLE
Fix requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/miniconda3:4.10.3p0
+FROM continuumio/miniconda3:4.11.0
 
 RUN apt-get update && apt-get install -y supervisor nginx gcc
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pydot
 pyyaml
 
 numpy
-nptyping
+nptyping==1.4.4
 pandas
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyyaml
 numpy
 nptyping
 pandas
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numpy
 nptyping==1.4.4
 pandas
 scipy
+scikit-learn


### PR DESCRIPTION
A clean Docker build was throwing errors for me due to breaking changes in `nptyping` v2. We could also drop `nptyping` as `numpy.typing` got more powerful lately. 

Also requirements that installed by conda when installing `scikit-survival` are explicitly listed in the `requirements.txt` now (`scipy`, `scikit-learn`). 
Otherwise @julianspaeth we could also switch to fully define the environment with a conda env file so we have all requirements in one place?

This PR also bumps up the Docker base image `miniconda` version.