### PR TITLE
Add drop rows with negative or zero timepoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY server_config/nginx /etc/nginx/sites-available/default
 COPY server_config/docker-entrypoint.sh /entrypoint.sh
 
 RUN conda config --append channels conda-forge
-RUN conda install -y -c sebp scikit-survival
+RUN conda install -y -c sebp scikit-survival==0.16.0
 
 COPY requirements.txt /app/requirements.txt
 RUN pip3 install -r ./app/requirements.txt

--- a/engine/app.py
+++ b/engine/app.py
@@ -247,7 +247,7 @@ class AppState:
 
     def update(self, message=None, progress=None, state=None):
         if message and len(message) > 40:
-            logging.debug(f"Truncated a long message. Original message: {message!r}")
+            self.app.log(f"Truncated a long message. Original message: {message!r}", logging.DEBUG)
             message = message[:39]
         if progress is not None and (progress < 0 or progress > 1):
             raise RuntimeError('progress must be between 0 and 1')

--- a/engine/app.py
+++ b/engine/app.py
@@ -4,6 +4,7 @@ import threading
 import time
 import traceback
 from time import sleep
+import textwrap
 
 from typing import Dict, List, Tuple
 
@@ -174,7 +175,7 @@ class App:
         self.current_state = transition[1]
 
     def log(self, msg, level=logging.INFO):
-        logging.log(level, msg)
+        logging.log(level, '\n'.join(['', *textwrap.wrap(str(msg), 120)]))
 
 
 class AppState:

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -672,7 +672,7 @@ class WriteResult(BlankState):
 
             # write pickled model
             pickle_output_path = os.path.join(split.output_dir, config.model_output)
-            logging.debug(f"Writing model to {pickle_output_path}")
+            self.app.log(f"Writing model to {pickle_output_path}")
             with open(pickle_output_path, "wb") as fh:
                 pickle.dump(sksurv_obj, fh)
 
@@ -749,7 +749,7 @@ class WriteResult(BlankState):
 
             # write model parameters as meta file
             meta_output_path = os.path.join(split.output_dir, config.meta_output)
-            logging.debug(f"Writing metadata to {meta_output_path}")
+            self.app.log(f"Writing metadata to {meta_output_path}", level=logging.DEBUG)
 
             with open(meta_output_path, "w") as fh:
                 yaml.dump(metadata, fh)

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -237,7 +237,7 @@ class ReadDataState(BlankState):
 class PreprocessDataState(BlankState):
 
     def run(self):
-        self.update(message='Check survival times for zero and negative timepoints', progress=0.08)
+        self.update(message='Check times for zero and neg. timepoints', progress=0.08)
         split_manager = self.app.internal.get('split_manager')
         for split in split_manager:
             if not split.data.get('opt_out'):

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -684,7 +684,7 @@ class WriteResult(BlankState):
             for feature_name, feature_weight in zip(features, weights):
                 beta[feature_name] = feature_weight
             bias = None
-            if sksurv_obj.fit_intercept is not None:
+            if sksurv_obj.fit_intercept:
                 bias = float(sksurv_obj.intercept_)
 
             # unpack timings

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -754,4 +754,5 @@ class WriteResult(BlankState):
             with open(meta_output_path, "w") as fh:
                 yaml.dump(metadata, fh)
 
+        self.update(message='Done', progress=1)
         return super().run()

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -257,7 +257,7 @@ class PreprocessDataState(BlankState):
                 if dropped_rows > 0:
                     self.update(
                         message=f'Dropped {dropped_rows} samples with zero or negative timepoints in {split.name}',
-                        state=STATE_ERROR
+                        state=STATE_RUNNING
                     )
 
         self.update(message='Log-transform survival times', progress=0.08)

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,6 +53,11 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
+    def _drop_rows(self, rows):
+        self.survival.time_to_event = np.drop(rows)
+        self.survival.event_indicator = np.drop(rows)
+        self.features = np.drop(rows)
+
     def drop_negative_and_zero_timepoints(self) -> int:
         """
         Drop rows with a negative or zero time to prepare data for log-transformation.
@@ -65,9 +70,7 @@ class SurvivalData:
         if n_bad_rows > 0:
             logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
             # drop rows in all arrays
-            self.survival.time_to_event = np.drop(bad_rows)
-            self.survival.event_indicator = np.drop(bad_rows)
-            self.features = np.drop(bad_rows)
+            self._drop_rows(rows=bad_rows)
         return n_bad_rows
 
     def log_transform_times(self):

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,10 +53,12 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
-    def _drop_rows(self, rows):
-        self.survival.time_to_event = np.drop(rows)
-        self.survival.event_indicator = np.drop(rows)
-        self.features = np.drop(rows)
+    def _drop_rows(self, rows_to_drop):
+        """Drop rows given by a truth array. Rows with value True are dropped in all arrays.
+        """
+        self.survival.time_to_event = self.survival.time_to_event[np.invert(rows_to_drop)]
+        self.survival.event_indicator = self.survival.event_indicator[np.invert(rows_to_drop)]
+        self.features = self.features[np.invert(rows_to_drop)]
 
     def drop_negative_and_zero_timepoints(self) -> int:
         """
@@ -70,7 +72,7 @@ class SurvivalData:
         if n_bad_rows > 0:
             logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
             # drop rows in all arrays
-            self._drop_rows(rows=bad_rows)
+            self._drop_rows(rows_to_drop=bad_rows)
         return n_bad_rows
 
     def log_transform_times(self):

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,6 +53,23 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
+    def drop_negative_and_zero_timepoints(self) -> int:
+        """
+        Drop rows with a negative or zero time to prepare data for log-transformation.
+
+        :return: Number of dropped rows
+        """
+        logging.info("Check data for negative and zero timepoints")
+        bad_rows = self.survival.time_to_event <= 0
+        n_bad_rows = bad_rows.sum()
+        if n_bad_rows > 0:
+            logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
+            # drop rows in all arrays
+            self.survival.time_to_event = np.drop(bad_rows)
+            self.survival.event_indicator = np.drop(bad_rows)
+            self.features = np.drop(bad_rows)
+        return n_bad_rows
+
     def log_transform_times(self):
         logging.info("Log transform times for regression objective")
         self.survival.time_to_event = np.log(self.survival.time_to_event)

--- a/logic/data.py
+++ b/logic/data.py
@@ -60,7 +60,7 @@ class SurvivalData:
 
     def drop_negative_and_zero_timepoints(self) -> int:
         """
-        Drop rows with a negative or zero time to prepare data for log-transformation.
+        Drop samples with a negative or zero time to prepare data for log-transformation.
 
         :return: Number of dropped rows
         """

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from api.http_web import web_server
 from app import app
 
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=logging.INFO,
     format="%(asctime)s %(levelname)s [%(filename)s %(name)s %(funcName)s (%(lineno)d)]: %(message)s",
 )
 


### PR DESCRIPTION
This PR adds checks for negative and zero values for the timestamps in the preprocessing of the data.
Positive values are needed for the log-transformation of the survival times.

Bad values are handled by dropping the offending rows.
The number of dropped rows are logged and published to the controller by setting an error state including the split name.