### PR TITLE
Allow user to define a value for censored entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ fc_survival_svm:
     sep: ","  # separator used in csv files
     label_survival_time: "tte"  # label for the time to event column
     label_event: "event"  # label for the event column
-    event_truth_value: True  # optional, default=True; value of an entry in the event column when an event occurred
+    event_value: '1'  # optional, default='1'; value of an entry in the event column when an event occurred
+    event_censored_value: '0'  # optional, default='0'; value of an entry in the event column when entry is censored
   split:
     mode: directory  # directory if cross validation was used before, else file
     dir: "cv"  # cv if cross validation app was used before, else .

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -210,7 +210,7 @@ class ReadDataState(BlankState):
             training_data: SurvivalData = read_survival_data(
                 training_data_path, sep=config.sep,
                 label_event=config.label_event, label_time_to_event=config.label_time_to_event,
-                event_truth_value=config.event_truth_value)
+                event_value=config.event_value, event_censored_value=config.event_censored_value)
 
             # get some metrics about data
             n_samples = training_data.n_samples
@@ -614,7 +614,7 @@ class GeneratePredictions(BlankState):
             X_test, y_test = logic.data.read_survival_data_np(
                 test_data_path, sep=config.sep,
                 label_event=config.label_event, label_time_to_event=config.label_time_to_event,
-                event_truth_value=config.event_truth_value)
+                event_value=config.event_value, event_censored_value=config.event_censored_value)
 
             predictions = svm.predict(X_test)
 
@@ -731,7 +731,8 @@ class WriteResult(BlankState):
                             split.input_dir, config.train_filename).replace(settings.INPUT_DIR, '.'),
                         "label_survival_time": config.label_time_to_event,
                         "label_event": config.label_event,
-                        "event_truth_value": config.event_truth_value,
+                        "event_value": config.event_value,
+                        "event_censored_value": config.event_censored_value,
                         "n_samples": split.data.get('n_samples'),
                         "n_censored": split.data.get('n_censored'),
                     },

--- a/engine/survival_svm.py
+++ b/engine/survival_svm.py
@@ -257,7 +257,7 @@ class PreprocessDataState(BlankState):
                 if dropped_rows > 0:
                     self.update(
                         message=f'Dropped {dropped_rows} samples with zero or negative timepoints in {split.name}',
-                        state=STATE_ERROR
+                        state=STATE_RUNNING
                     )
 
         self.update(message='Log-transform survival times', progress=0.08)

--- a/logic/config.py
+++ b/logic/config.py
@@ -52,7 +52,8 @@ class Config:
         self.sep: Optional[str] = None
         self.label_time_to_event: Optional[str] = None
         self.label_event: Optional[str] = None
-        self.event_truth_value: Optional[str] = None
+        self.event_value: Optional[str] = None
+        self.event_censored_value: Optional[str] = None
 
         self.mode: Optional[SplitMode] = None
         self.dir = "."
@@ -82,7 +83,8 @@ class Config:
             config.sep = config_yml['format']['sep']
             config.label_time_to_event = config_yml['format']['label_survival_time']
             config.label_event = config_yml['format']['label_event']
-            config.event_truth_value = config_yml['format'].get('event_truth_value', True)  # default value
+            config.event_value = str(config_yml['format'].get('event_value', '1'))
+            config.event_censored_value = str(config_yml['format'].get('event_censored_value', '0'))
 
             if config_yml.get('svm'):
                 config.parameters.alpha = config_yml['svm']['alpha']
@@ -120,9 +122,13 @@ class Config:
         config.label_time_to_event = form.get('label_time_to_event')
         config.label_event = form.get('label_event')
         if form.get('event_truth_value') != "":
-            config.event_truth_value = form.get('event_truth_value', True)  # default value
+            config.event_value = str(form.get('event_value', '1'))  # default value
         else:
-            config.event_truth_value = True  # default value
+            config.event_value = '1'  # default value
+        if form.get('event_censored_value') != "":
+            config.event_censored_value = str(form.get('event_censored_value', '0'))  # default value
+        else:
+            config.event_censored_value = '0'  # default value
 
         if is_coordinator:
             config.parameters.alpha = int(form.get('alpha'))

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,6 +53,11 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
+    def _drop_rows(self, rows):
+        self.survival.time_to_event = np.drop(rows)
+        self.survival.event_indicator = np.drop(rows)
+        self.features = np.drop(rows)
+
     def drop_negative_and_zero_timepoints(self) -> int:
         """
         Drop rows with a negative or zero time to prepare data for log-transformation.
@@ -65,9 +70,7 @@ class SurvivalData:
         if n_bad_rows > 0:
             logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
             # drop rows in all arrays
-            self.survival.time_to_event = np.drop(bad_rows)
-            self.survival.event_indicator = np.drop(bad_rows)
-            self.features = np.drop(bad_rows)
+            self._drop_rows(rows=bad_rows)
         return n_bad_rows
 
     def log_transform_times(self):

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,10 +53,12 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
-    def _drop_rows(self, rows):
-        self.survival.time_to_event = np.drop(rows)
-        self.survival.event_indicator = np.drop(rows)
-        self.features = np.drop(rows)
+    def _drop_rows(self, rows_to_drop):
+        """Drop rows given by a truth array. Rows with value True are dropped in all arrays.
+        """
+        self.survival.time_to_event = self.survival.time_to_event[np.invert(rows_to_drop)]
+        self.survival.event_indicator = self.survival.event_indicator[np.invert(rows_to_drop)]
+        self.features = self.features[np.invert(rows_to_drop)]
 
     def drop_negative_and_zero_timepoints(self) -> int:
         """
@@ -70,7 +72,7 @@ class SurvivalData:
         if n_bad_rows > 0:
             logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
             # drop rows in all arrays
-            self._drop_rows(rows=bad_rows)
+            self._drop_rows(rows_to_drop=bad_rows)
         return n_bad_rows
 
     def log_transform_times(self):

--- a/logic/data.py
+++ b/logic/data.py
@@ -53,6 +53,23 @@ class SurvivalData:
             time_to_event=time_to_event,
         )
 
+    def drop_negative_and_zero_timepoints(self) -> int:
+        """
+        Drop rows with a negative or zero time to prepare data for log-transformation.
+
+        :return: Number of dropped rows
+        """
+        logging.info("Check data for negative and zero timepoints")
+        bad_rows = self.survival.time_to_event <= 0
+        n_bad_rows = bad_rows.sum()
+        if n_bad_rows > 0:
+            logging.warning(f"Dropping {n_bad_rows} rows with negative or zero times")
+            # drop rows in all arrays
+            self.survival.time_to_event = np.drop(bad_rows)
+            self.survival.event_indicator = np.drop(bad_rows)
+            self.features = np.drop(bad_rows)
+        return n_bad_rows
+
     def log_transform_times(self):
         logging.info("Log transform times for regression objective")
         self.survival.time_to_event = np.log(self.survival.time_to_event)

--- a/logic/data.py
+++ b/logic/data.py
@@ -60,7 +60,7 @@ class SurvivalData:
 
     def drop_negative_and_zero_timepoints(self) -> int:
         """
-        Drop rows with a negative or zero time to prepare data for log-transformation.
+        Drop samples with a negative or zero time to prepare data for log-transformation.
 
         :return: Number of dropped rows
         """

--- a/sample_data/veterans/client_0/config.yml
+++ b/sample_data/veterans/client_0/config.yml
@@ -12,7 +12,8 @@ fc_survival_svm:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 1  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '1'  # optional, default='1'; value of an entry in the event column when an event occurred
+    event_censored_value: '0'  # optional, default='0'; value of an entry in the event column when censored
   split:
     mode: directory  # directory if cross validation was used before, else file
     dir: cv  # data if cross validation app was used before, else .

--- a/sample_data/veterans/client_1/config.yml
+++ b/sample_data/veterans/client_1/config.yml
@@ -12,7 +12,8 @@ fc_survival_svm:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 1  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '1'  # optional, default='1'; value of an entry in the event column when an event occurred
+    event_censored_value: '0'  # optional, default='0'; value of an entry in the event column when censored
   split:
     mode: directory  # directory if cross validation was used before, else file
     dir: cv  # data if cross validation app was used before, else .

--- a/sample_data/veterans/client_2/config.yml
+++ b/sample_data/veterans/client_2/config.yml
@@ -12,7 +12,8 @@ fc_survival_svm:
     sep: ","
     label_survival_time: "time"
     label_event: "status"
-    event_truth_value: 1  # optional, default=True; value of an entry in the event column when a event occurred
+    event_value: '1'  # optional, default='1'; value of an entry in the event column when an event occurred
+    event_censored_value: '0'  # optional, default='0'; value of an entry in the event column when censored
   split:
     mode: directory  # directory if cross validation was used before, else file
     dir: cv  # data if cross validation app was used before, else .

--- a/templates/web_config_form.html
+++ b/templates/web_config_form.html
@@ -69,9 +69,15 @@
                     </div>
                 </div>
                 <div class="field">
-                    <label class="label">Value when event occurred (leave empty for <code>True</code>)</label>
+                    <label class="label">Value when event occurred</label>
                     <div class="control">
-                        <input name="event_truth_value" class="input" type="text" placeholder="" value="">
+                        <input name="event_value" class="input" type="text" placeholder="" value="1">
+                    </div>
+                </div>
+                <div class="field">
+                    <label class="label">Value when event is censored</label>
+                    <div class="control">
+                        <input name="event_censored_value" class="input" type="text" placeholder="" value="0">
                     </div>
                 </div>
 


### PR DESCRIPTION
The user can submit a value for censored and uncensored rows of the event column.
Value is parsed from `yaml` files and the web form.
Rows that match neither are dropped.
`README` and sample data is changed accordingly.